### PR TITLE
Remove no-op buttons

### DIFF
--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -3,7 +3,6 @@ import { AvatarFallback, AvatarImage, Avatar } from './ui/avatar'
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -35,11 +34,6 @@ const UserNav: React.FC = () => {
             </p>
           </div>
         </DropdownMenuLabel>
-        <DropdownMenuGroup>
-          <DropdownMenuItem>Profile</DropdownMenuItem>
-
-          <DropdownMenuItem>Get Verified</DropdownMenuItem>
-        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => void signOut()}>
           Log out


### PR DESCRIPTION
## Remove no-op buttons 

**Description:**
Remove the `Get Verified` and `Profile` buttons from the application. These buttons were not performing any actions, leading to potential confusion for users. The removal is intended to streamline the user interface and enhance overall user experience.

**Deployment Considerations:**
No special actions are required.

### Screenshots
**Before:**
![Screenshot from 2024-06-10 13-42-11](https://github.com/filecoin-project/filplus-registry/assets/67787091/1a8d9736-975a-4778-88de-643bcc84b33c)

**After:**
![Screenshot from 2024-06-10 13-41-46](https://github.com/filecoin-project/filplus-registry/assets/67787091/f2e70305-74cf-42d3-91fc-3c3efad0e2ed)

