### PR TITLE
Fix allocation on unfinished KYC

### DIFF
--- a/src/components/cards/AppInfoCard.tsx
+++ b/src/components/cards/AppInfoCard.tsx
@@ -371,6 +371,7 @@ const AppInfoCard: React.FC<ComponentProps> = ({
         case 'Submitted':
         case 'AdditionalInfoRequired':
         case 'AdditionalInfoSubmitted':
+        case 'KYCRequested':
           if (userName != null) {
             setAllocationAmountConfig((prev) => {
               return {


### PR DESCRIPTION
# Pull Request Template

## Description

Allow allocator to allocate even if KYC was requested and not finished (perhaps it was done with some other method).

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)