### PR TITLE
fix: Wrong link to the application on the grid view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -374,12 +374,12 @@ export default function Home(): JSX.Element {
                 repo={
                   selectedAllocator && typeof selectedAllocator !== 'string'
                     ? selectedAllocator.repo
-                    : ''
+                    : undefined
                 }
                 owner={
                   selectedAllocator && typeof selectedAllocator !== 'string'
                     ? selectedAllocator.owner
-                    : ''
+                    : undefined
                 }
                 key={app.ID}
               />


### PR DESCRIPTION
## Fix the wrong link to the application on the grid view
**Description:**
The "Detail" button on the grid view, which previously did not navigate users to the application page due to a broken link, has now been fixed.

**Deployment Considerations:**
No special actions are required.

## Screenshot:
![fixed_button](https://github.com/filecoin-project/filplus-registry/assets/67787091/2f6749ad-0fec-47e3-857c-54337051704d)
