### PR TITLE
Fix progress bar visibility for unused last allocation

### DIFF
--- a/src/components/cards/AppInfoCard.tsx
+++ b/src/components/cards/AppInfoCard.tsx
@@ -185,11 +185,14 @@ const AppInfoCard: React.FC<ComponentProps> = ({
 
         const allocationAmount = anyToBytes(lastAllocationUnit)
 
-        if (
-          allocationAmount < allowance ||
-          isApplicationUpdatedLessThanOneMinuteAgo()
-        ) {
+        if (isApplicationUpdatedLessThanOneMinuteAgo()) {
           setIsProgressBarVisible(false)
+          return
+        }
+
+        if (allocationAmount < allowance) {
+          setIsProgressBarVisible(true)
+          setProgress(0)
           return
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes visibility of the application info last allocation progress bar. If client did not make deals yet and still has previous allocation to use progress bar will remain at 0% indicating unused last allocation.

Fixes # (issue reference)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

