### PR TITLE
[FIL-598] Display allocation unit according to the requested value 

### DIFF
--- a/src/components/AppHistory.tsx
+++ b/src/components/AppHistory.tsx
@@ -1,8 +1,9 @@
 'use client'
-import { type AllocationRequest } from '@/type'
+import type { AllocationUnit, AllocationRequest } from '@/type'
 import AppHistoryCard from './cards/AppHistoryCard'
 import moment from 'moment'
 import { anyToBytes, bytesToiB } from '@/lib/utils'
+import { splitString } from '@/helpers/calculateAmountToRefill'
 
 interface ComponentProps {
   datacapAllocations: AllocationRequest[]
@@ -18,7 +19,6 @@ const AppHistory: React.FC<ComponentProps> = ({
   const sortedAllocations = [...datacapAllocations].sort((a, b) => {
     return moment(b['Created At']).valueOf() - moment(a['Created At']).valueOf()
   })
-
   const totalAllocation = datacapAllocations?.reduce(
     (acc: number, curr: AllocationRequest) => {
       const amount = anyToBytes(curr['Allocation Amount'])
@@ -26,8 +26,11 @@ const AppHistory: React.FC<ComponentProps> = ({
     },
     0,
   )
-
-  const totalAllocationFormatted = bytesToiB(totalAllocation)
+  const [, unit] = splitString(totalRequestedAmount)
+  const totalAllocationFormatted = bytesToiB(
+    totalAllocation,
+    unit as AllocationUnit,
+  )
 
   return (
     <>

--- a/src/components/cards/AppInfoCard.tsx
+++ b/src/components/cards/AppInfoCard.tsx
@@ -819,9 +819,8 @@ const AppInfoCard: React.FC<ComponentProps> = ({
       toast.error('Datacap exceeds the total requested amount')
       return
     }
-
-    const againToText = bytesToiB(bytes)
-
+    const unit = letters?.join().replaceAll(',', '')
+    const againToText = bytesToiB(bytes, unit as AllocationUnit)
     return againToText
   }
 

--- a/src/components/cards/AppInfoCard.tsx
+++ b/src/components/cards/AppInfoCard.tsx
@@ -819,9 +819,7 @@ const AppInfoCard: React.FC<ComponentProps> = ({
       toast.error('Datacap exceeds the total requested amount')
       return
     }
-    const unit = letters?.join().replaceAll(',', '')
-    const againToText = bytesToiB(bytes, unit as AllocationUnit)
-    return againToText
+    return datacap
   }
 
   const handleRequestKyc = async (): Promise<void> => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,9 @@
-import type { ParsedTransaction, AllocationRequest, Application } from '@/type'
+import type {
+  ParsedTransaction,
+  AllocationRequest,
+  Application,
+  AllocationUnit,
+} from '@/type'
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import bytes from 'bytes-iec'
@@ -87,9 +92,9 @@ export const shortenUrl = (
  * @param inputBytes
  * @returns string
  */
-export function bytesToiB(inputBytes: number): string {
+export function bytesToiB(inputBytes: number, unit?: AllocationUnit): string {
   try {
-    const parsedValue = bytes(inputBytes, { mode: 'binary' })
+    const parsedValue = bytes(inputBytes, { mode: 'binary', unit })
     if (parsedValue) {
       return parsedValue
     } else {


### PR DESCRIPTION
Additionally, the requested value is kept in the same unit as provided, without being rounded to the nearest unit.
![Screenshot from 2025-02-07 14-22-37](https://github.com/user-attachments/assets/693e12d7-0cf9-4c04-b55c-b99f5e965c35)
